### PR TITLE
Clarify command sequence in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The reference output will be in the reference-output directory. Each test has an
 To grade the solution in STUDENT-SOLUTION-1 (or any other directory):
 
 > ./MAKE-REFERENCE.sh
+
 > ./grade.sh STUDENT-SOLUTION-1
 
 The results will be in results.json.


### PR DESCRIPTION
Viewed from the github readme preview, the previous markdown makes it seem (misleadingly) like the commands are on one line: `./MAKE-REFERENCE.sh ./grade.sh STUDENT-SOLUTION-1`. The program terminates successfully, but as expected, the intended effect is not delivered.

The intention was to run these in succession. Adding the newline character separates these onto different lines, as desired.